### PR TITLE
Added django_extensions, docker exec -i -t degree_planner python mana…

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -5,4 +5,6 @@ ENV C_FORCE_ROOT true
 COPY ./src /src
 RUN pip install -r /src/requirements.txt
 
-CMD ["python", "/src/manage.py", "runserver", "0.0.0.0:8000"]
+WORKDIR /src/
+
+CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,9 @@ down:
 	docker-compose down --remove-orphans
 logs:
 	docker logs $(CONTAINER)
-exec_local:
-	docker run --rm -i -t degree_planner_local /bin/bash
 exec:
-	docker run --rm -i -t degree_planner /bin/bash
+	docker exec -i -t degree_planner /bin/bash
+shell:
+	docker exec -i -t degree_planner python manage.py shell_plus
 reset: down up_build
 	@echo "Restarting..."

--- a/src/config/settings/base.py
+++ b/src/config/settings/base.py
@@ -16,7 +16,7 @@ if READ_DOT_ENV_FILE:
     # OS environment variables take precedence over variables from .env
     env.read_env(str(ROOT_DIR.path('.env')))
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ["*"]
 
 SECRET_KEY = 'DJANGO_SECRET_KEY'
 
@@ -71,11 +71,12 @@ DJANGO_APPS = [
     'django.contrib.admin',
 ]
 THIRD_PARTY_APPS = [
-
+ 
 ]
 LOCAL_APPS = [
-
+    'planner',
 ]
+
 # https://docs.djangoproject.com/en/dev/ref/settings/#installed-apps
 INSTALLED_APPS = DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS
 

--- a/src/config/settings/local.py
+++ b/src/config/settings/local.py
@@ -5,14 +5,12 @@ from .base import env
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#debug
 DEBUG = env.bool('DJANGO_DEBUG', default=True)
+
 # https://docs.djangoproject.com/en/dev/ref/settings/#secret-key
 SECRET_KEY = env('DJANGO_SECRET_KEY', default='fOqtAorZrVqWYbuMPOcZnTzw2D5bKeHGpXUwCaNBnvFUmO1njCQZGz05x1BhDG0E')
+
 # https://docs.djangoproject.com/en/dev/ref/settings/#allowed-hosts
-ALLOWED_HOSTS = [
-    "localhost",
-    "0.0.0.0",
-	"127.0.0.1",
-]
+ALLOWED_HOSTS = ["localhost", "0.0.0.0", "127.0.0.1"]
 
 
 # CACHES
@@ -29,7 +27,7 @@ CACHES = {
 # django-debug-toolbar
 # ------------------------------------------------------------------------------
 # https://django-debug-toolbar.readthedocs.io/en/latest/installation.html#prerequisites
-INSTALLED_APPS += ['debug_toolbar']  # noqa F405
+INSTALLED_APPS += ['debug_toolbar', 'django_extensions']  # noqa F405
 # https://django-debug-toolbar.readthedocs.io/en/latest/installation.html#middleware
 MIDDLEWARE += ['debug_toolbar.middleware.DebugToolbarMiddleware']  # noqa F405
 # https://django-debug-toolbar.readthedocs.io/en/latest/configuration.html#debug-toolbar-config

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -15,3 +15,4 @@ Unidecode==0.4.21
 # Local
 django-debug-toolbar==1.9.1
 sqlparse==0.2.4
+django-extensions


### PR DESCRIPTION
This adds `make shell` which will land you in a django `./manage.py shell` session *but* locally it will use `shell_plus` which does some magic stuff like auto imports, etc. 

Example:
```bash
➜  degree_planner git:(django_extensions) ✗ make shell
docker exec -i -t degree_planner python manage.py shell_plus
# Shell Plus Model Imports
from django.contrib.admin.models import LogEntry
from django.contrib.auth.models import Group, Permission, User
from django.contrib.contenttypes.models import ContentType
from django.contrib.sessions.models import Session
from django.contrib.sites.models import Site
# Shell Plus Django Imports
from django.core.cache import cache
from django.conf import settings
from django.contrib.auth import get_user_model
from django.db import transaction
from django.db.models import Avg, Case, Count, F, Max, Min, Prefetch, Q, Sum, When, Exists, OuterRef, Subquery
from django.utils import timezone
from django.urls import reverse
Python 3.6.5 (default, Mar 31 2018, 01:15:58)
[GCC 4.9.2] on linux
Type "help", "copyright", "credits" or "license" for more information.
(InteractiveConsole)
>>>
```

